### PR TITLE
fix: replace free-text provider_type prompt with selection list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Config lives at `~/.config/cpm/models.json`:
 |---|---|---|
 | `name` | Yes | Display name for the provider |
 | `base_url` | Yes | Provider API base URL |
-| `provider_type` | No | `openai` (default), `azure`, or `anthropic` |
+| `provider_type` | No | `openai` (default), `azure`, or `anthropic`. Use `openai` for any OpenAI Chat Completions-compatible endpoint (OpenAI, OpenRouter, Ollama, vLLM, etc.) |
 | `api_key_env` | No | Name of env var holding the API key. Empty or omitted = no auth (e.g. Ollama) |
 | `models[].id` | Yes | Model identifier passed to the provider |
 | `models[].max_prompt_tokens` | No | Sets `COPILOT_PROVIDER_MAX_PROMPT_TOKENS` |
@@ -124,6 +124,20 @@ Or add a block to the `providers` array:
   "models": [
     { "id": "llama3.2", "max_prompt_tokens": 128000, "max_output_tokens": 4096 },
     { "id": "qwen2.5-coder", "max_prompt_tokens": 128000, "max_output_tokens": 8192 }
+  ]
+}
+```
+
+**Using OpenRouter?** Set `provider_type` to `openai` — OpenRouter exposes an OpenAI-compatible API:
+
+```json
+{
+  "name": "OpenRouter",
+  "base_url": "https://openrouter.ai/api/v1",
+  "provider_type": "openai",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "models": [
+    { "id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free", "max_prompt_tokens": 128000, "max_output_tokens": 16000 }
   ]
 }
 ```

--- a/cpm.ps1
+++ b/cpm.ps1
@@ -97,6 +97,43 @@ function _cpm_clear {
     Write-Host "Cleared all Copilot provider env vars."
 }
 
+# -- provider type picker -------------------------------------------------
+
+function Get-CpmProviderType {
+    param([string]$Current = "")
+
+    $validTypes = @("openai", "anthropic", "azure")
+
+    Write-Host "  Provider type:"
+    Write-Host "    1) openai    - OpenAI-compatible APIs (OpenAI, OpenRouter, Ollama, etc.)"
+    Write-Host "    2) anthropic - Anthropic Claude API"
+    Write-Host "    3) azure     - Native Azure OpenAI endpoints"
+    Write-Host ""
+
+    $defaultNum = switch ($Current) {
+        "anthropic" { "2" }
+        "azure"     { "3" }
+        default     { "1" }
+    }
+
+    if ($Current -and $Current -notin $validTypes) {
+        Write-Warning "Current provider type '$Current' is invalid. Select a valid type below."
+        Write-Host ""
+        $defaultNum = "1"
+    }
+
+    while ($true) {
+        $typeChoice = Read-Host "  Pick (1-3) [$defaultNum]"
+        if (-not $typeChoice) { $typeChoice = $defaultNum }
+        switch ($typeChoice) {
+            "1" { return "openai" }
+            "2" { return "anthropic" }
+            "3" { return "azure" }
+            default { Write-Host "  Invalid choice. Enter 1, 2, or 3." -ForegroundColor Red }
+        }
+    }
+}
+
 # -- add provider/model wizard --------------------------------------------
 
 function _cpm_add {
@@ -139,8 +176,7 @@ function _cpm_add {
         $purl = Read-Host "  Base URL (e.g. https://openrouter.ai/api/v1)"
         if (-not $purl) { Write-Host "Cancelled."; return }
 
-        $ptype = Read-Host "  Provider type [openai]"
-        if (-not $ptype) { $ptype = "openai" }
+        $ptype = Get-CpmProviderType
 
         $pkey = Read-Host "  API key env var name (e.g. OPENROUTER_API_KEY, blank for none)"
 
@@ -313,8 +349,7 @@ function _cpm_update {
         if (-not $newUrl) { $newUrl = $p.base_url }
 
         $curType = if ($p.provider_type) { $p.provider_type } else { "openai" }
-        $newType = Read-Host "  Provider type [$curType]"
-        if (-not $newType) { $newType = $curType }
+        $newType = Get-CpmProviderType -Current $curType
 
         $curKey = if ($p.api_key_env) { $p.api_key_env } else { "" }
         $newKey = Read-Host "  API key env var [$curKey]"
@@ -543,6 +578,14 @@ function _cpm_pick {
     }
 
     $selected = $entries[$choice - 2]
+
+    $validTypes = @("openai", "anthropic", "azure")
+    if ($selected.ProviderType -notin $validTypes) {
+        Write-Host ""
+        Write-Warning "Provider type '$($selected.ProviderType)' is not valid (must be openai, anthropic, or azure)."
+        Write-Host "  Run 'cpm update' to fix this provider's configuration." -ForegroundColor Yellow
+        return
+    }
 
     $env:COPILOT_PROVIDER_BASE_URL = $selected.BaseUrl
     $env:COPILOT_PROVIDER_TYPE = $selected.ProviderType

--- a/cpm.sh
+++ b/cpm.sh
@@ -147,6 +147,45 @@ _cpm_launch() {
   fi
 }
 
+# ── provider type picker ─────────────────────────────────────────────────
+# Sets _CPM_PROVIDER_TYPE to the chosen value. Pass current type as $1.
+
+_cpm_pick_provider_type() {
+  local current="${1:-}"
+
+  echo "  Provider type:"
+  echo "    1) openai    — OpenAI-compatible APIs (OpenAI, OpenRouter, Ollama, etc.)"
+  echo "    2) anthropic — Anthropic Claude API"
+  echo "    3) azure     — Native Azure OpenAI endpoints"
+  echo ""
+
+  local default_num="1"
+  case "$current" in
+    anthropic) default_num="2" ;;
+    azure)     default_num="3" ;;
+    openai)    default_num="1" ;;
+    "")        default_num="1" ;;
+    *)
+      echo "  ⚠ Current provider type '$current' is invalid. Select a valid type below." >&2
+      echo "" >&2
+      default_num="1"
+      ;;
+  esac
+
+  local type_choice
+  while true; do
+    printf "  Pick (1-3) [%s]: " "$default_num"
+    read -r type_choice
+    type_choice="${type_choice:-$default_num}"
+    case "$type_choice" in
+      1) _CPM_PROVIDER_TYPE="openai";    break ;;
+      2) _CPM_PROVIDER_TYPE="anthropic"; break ;;
+      3) _CPM_PROVIDER_TYPE="azure";     break ;;
+      *) echo "  Invalid choice. Enter 1, 2, or 3." >&2 ;;
+    esac
+  done
+}
+
 # ── add provider/model wizard ────────────────────────────────────────────
 
 _cpm_add() {
@@ -210,9 +249,9 @@ _cpm_add() {
       return 1
     fi
 
-    printf "  Provider type [openai]: "
-    read -r ptype
-    ptype="${ptype:-openai}"
+    _CPM_PROVIDER_TYPE=""
+    _cpm_pick_provider_type
+    ptype="$_CPM_PROVIDER_TYPE"
 
     printf "  API key env var name (e.g. OPENROUTER_API_KEY, blank for none): "
     read -r pkey
@@ -453,9 +492,9 @@ _cpm_update_provider() {
   read -r new_url
   new_url="${new_url:-$cur_url}"
 
-  printf "  Provider type [%s]: " "$cur_type"
-  read -r new_type
-  new_type="${new_type:-$cur_type}"
+  _CPM_PROVIDER_TYPE=""
+  _cpm_pick_provider_type "$cur_type"
+  new_type="$_CPM_PROVIDER_TYPE"
 
   printf "  API key env var [%s]: " "$cur_key"
   read -r new_key
@@ -795,6 +834,17 @@ _cpm_pick() {
   model=$(printf '%s' "$selected" | jq -r '.model')
   max_prompt=$(printf '%s' "$selected" | jq -r '.max_prompt')
   max_output=$(printf '%s' "$selected" | jq -r '.max_output')
+
+  # Validate provider_type before exporting
+  case "$provider_type" in
+    openai|anthropic|azure) ;;
+    *)
+      echo "" >&2
+      echo "⚠ Provider type '$provider_type' is not valid (must be openai, anthropic, or azure)." >&2
+      echo "  Run 'cpm update' to fix this provider's configuration." >&2
+      return 1
+      ;;
+  esac
 
   # Set env vars
   export COPILOT_PROVIDER_BASE_URL="$base_url"


### PR DESCRIPTION
Fixes #5

## Problem
When running `cpm add` or `cpm update`, the provider type prompt accepted any free-text string. GitHub Copilot CLI only supports three valid values for `COPILOT_PROVIDER_TYPE`: `openai`, `anthropic`, and `azure`. Users (like the reporter) who entered `openrouter` instead of `openai` got a cryptic error from VS Code/Copilot CLI later — with no hint about what went wrong or how to fix it.

## Changes

### `cpm.sh` / `cpm.ps1`
- **New `_cpm_pick_provider_type` / `Get-CpmProviderType` helpers** — numbered selection menu instead of free-text:
  ```
  Provider type:
    1) openai    — OpenAI-compatible APIs (OpenAI, OpenRouter, Ollama, etc.)
    2) anthropic — Anthropic Claude API
    3) azure     — Native Azure OpenAI endpoints
  Pick (1-3) [1]:
  ```
- **`cpm add`** — uses the picker when creating a new provider
- **`cpm update`** — uses the picker when editing a provider; pre-selects the current valid type, or shows a warning and forces a fresh pick if the stored value is already invalid
- **`cpm` (picker)** — validates `provider_type` from config before exporting env vars; fails early with a clear message pointing to `cpm update` if invalid

### `README.md`
- Updated `provider_type` field description to list all valid values and clarify that `openai` covers OpenRouter, Ollama, vLLM, etc.
- Added an explicit OpenRouter config example so users don't guess