### PR TITLE
fix: enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must use LF line endings to run on Linux/macOS
+*.sh text eol=lf
+.gitattributes text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-# Shell scripts must use LF line endings to run on Linux/macOS
+# Force LF line endings so scripts run on Linux/macOS regardless of local core.autocrlf
 *.sh text eol=lf
 .gitattributes text eol=lf

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Enter number (1-3): 1
 **Bash / Zsh (macOS, Linux)**
 
 ```bash
-git clone https://github.com/your-user/cpm.git && cd cpm && bash install.sh
+git clone https://github.com/burkeholland/cpm.git && cd cpm && bash install.sh
 ```
 
 **PowerShell (Windows, macOS, Linux)**
 
 ```powershell
-git clone https://github.com/your-user/cpm.git; cd cpm; .\install.ps1
+git clone https://github.com/burkeholland/cpm.git; cd cpm; .\install.ps1
 ```
 
 The installer will:


### PR DESCRIPTION
## Problem

The `install.sh` and `cpm.sh` scripts fail to execute on Linux when the repository is cloned on a system with `core.autocrlf=true` (the default Git for Windows setting). Git converts LF → CRLF on checkout, producing scripts with Windows-style line endings that Bash cannot parse, resulting in errors like:

```
/usr/bin/env: 'bash\r': No such file or directory
```

Even on Windows, shell scripts should use LF — WSL, Git Bash, and modern PowerShell all handle LF without issues.

## Solution

This PR adds a `.gitattributes` file that explicitly forces LF line endings for all `*.sh` files:

```
*.sh text eol=lf
```

- **Overrides `core.autocrlf`**: The `.gitattributes` setting takes priority over the user's local Git configuration, ensuring shell scripts are always checked out with LF line endings regardless of platform.
- **Future-proof**: Any new `.sh` files added to the repository will automatically get LF treatment.

### Additional fix
- Corrected the repository URL in `README.md` clone instructions from the placeholder `your-user` to the actual owner `burkeholland`.

## Verification

Before this change (with `core.autocrlf=true`):
```
$ file install.sh cpm.sh
install.sh: ... with CRLF line terminators
cpm.sh:     ... with CRLF line terminators
```

After this change, the `.gitattributes` rule ensures LF checkout regardless of local config.