### PR TITLE
feat: add cpm discover — dynamically discover OpenRouter models

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ sudo dnf install jq
 | `cpm keys` | Show API key status and set missing keys |
 | `cpm edit` | Open `models.json` in `$EDITOR` |
 | `cpm import` | Import models from VS Code `chatLanguageModels.json` |
+| `cpm discover` | Discover & select models live from OpenRouter API |
 | `cpm clear` | Unset all Copilot provider env vars |
 | `cpm help` | Show help |
 

--- a/cpm.sh
+++ b/cpm.sh
@@ -29,6 +29,7 @@ cpm() {
     update)  _cpm_update ;;
     edit)    _cpm_edit ;;
     import)  _cpm_import ;;
+    discover) _cpm_discover ;;
     clear)   _cpm_clear ;;
     keys)    _cpm_keys ;;
     config)  shift; _cpm_config "$@" ;;
@@ -594,6 +595,211 @@ _cpm_update_model() {
   echo "✓ Updated $cur_pn > $new_id"
 }
 
+# ── discover models from OpenRouter API ────────────────────────────────
+
+_CPM_OR_API="https://openrouter.ai/api/v1/models?supported_parameters=tools"
+_CPM_OR_BASE_URL="https://openrouter.ai/api/v1"
+_CPM_OR_PROVIDER_TYPE="openai"
+
+_cpm_discover() {
+  # guard: curl
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "cpm discover: curl is required." >&2
+    return 1
+  fi
+
+  echo ""
+  echo "  Fetching models from OpenRouter..."
+  echo ""
+
+  local raw_json
+  raw_json=$(curl -sSL --connect-timeout 10 "$_CPM_OR_API" 2>/dev/null)
+
+  if [ -z "$raw_json" ]; then
+    echo "  Failed to fetch models. Check your internet connection." >&2
+    return 1
+  fi
+
+  local total_count
+  total_count=$(printf '%s' "$raw_json" | jq '.data | length' 2>/dev/null)
+
+  if [ -z "$total_count" ] || [ "$total_count" -eq 0 ]; then
+    echo "  No models returned from OpenRouter API." >&2
+    return 1
+  fi
+
+  # Build a flat list of { provider_group, model_id, name, context }
+  local models_json
+  models_json=$(printf '%s' "$raw_json" | jq '[.data[] | {
+    group: (.id | split("/")[0]),
+    id: .id,
+    name: (.id | split("/")[1:] | join("/")),
+    context: (.top_provider.context_length // .context_length // 0),
+    max_output: (.top_provider.max_completion_tokens // 0)
+  }]')
+
+  local groups
+  groups=$(printf '%s' "$models_json" | jq -r '[group_by(.group)[] | { group: .[0].group, count: length }] | sort_by(.group)')
+
+  local group_count
+  group_count=$(printf '%s' "$groups" | jq 'length')
+
+  echo "  Found $total_count models with tool-calling support"
+  echo "  across $group_count provider groups."
+  echo ""
+
+  # Step 1: pick a provider group
+  echo "  Provider groups:"
+  echo ""
+
+  local gi=0
+  while [ "$gi" -lt "$group_count" ]; do
+    local gname gcount
+    gname=$(printf '%s' "$groups" | jq -r ".[$gi].group")
+    gcount=$(printf '%s' "$groups" | jq -r ".[$gi].count")
+    printf "  %3d) %-20s (%d models)\n" "$((gi + 1))" "$gname" "$gcount"
+    gi=$((gi + 1))
+  done
+
+  if [ "$group_count" -eq 0 ]; then
+    echo "  No provider groups found." >&2
+    return 1
+  fi
+
+  echo ""
+  local gchoice
+  while true; do
+    printf "  Pick a group (1-%d): " "$group_count"
+    read -r gchoice
+    case "$gchoice" in
+      ''|*[!0-9]*) echo "  Invalid choice." >&2; continue ;;
+    esac
+    if [ "$gchoice" -ge 1 ] && [ "$gchoice" -le "$group_count" ]; then
+      break
+    fi
+    echo "  Invalid choice." >&2
+  done
+
+  local selected_group
+  selected_group=$(printf '%s' "$groups" | jq -r ".[$((gchoice - 1))].group")
+  echo ""
+
+  # Step 2: pick a model from the selected group
+  local group_models
+  group_models=$(printf '%s' "$models_json" | jq -c --arg g "$selected_group" '[.[] | select(.group == $g)]')
+
+  local group_model_count
+  group_model_count=$(printf '%s' "$group_models" | jq 'length')
+
+  echo "  Models in '$selected_group':"
+  echo ""
+
+  local mi=0
+  while [ "$mi" -lt "$group_model_count" ]; do
+    local mid mname mctx
+    mid=$(printf '%s' "$group_models" | jq -r ".[$mi].id")
+    mname=$(printf '%s' "$group_models" | jq -r ".[$mi].name")
+    mctx=$(printf '%s' "$group_models" | jq -r ".[$mi].context")
+    local ctx_fmt=""
+    if [ "$mctx" -gt 0 ] 2>/dev/null; then
+      if [ "$mctx" -ge 1000000 ]; then
+        ctx_fmt="$((mctx / 1000000)).$(((mctx % 1000000) / 100000))M ctx"
+      else
+        ctx_fmt="$((mctx / 1000))k ctx"
+      fi
+    fi
+    printf "  %3d) %-45s %s\n" "$((mi + 1))" "$mid" "$ctx_fmt"
+    mi=$((mi + 1))
+  done
+
+  echo ""
+  local mchoice
+  while true; do
+    printf "  Pick a model (1-%d): " "$group_model_count"
+    read -r mchoice
+    case "$mchoice" in
+      ''|*[!0-9]*) echo "  Invalid choice." >&2; continue ;;
+    esac
+    if [ "$mchoice" -ge 1 ] && [ "$mchoice" -le "$group_model_count" ]; then
+      break
+    fi
+    echo "  Invalid choice." >&2
+  done
+
+  local selected_idx=$((mchoice - 1))
+  local selected_id selected_ctx selected_output
+  selected_id=$(printf '%s' "$group_models" | jq -r ".[$selected_idx].id")
+  selected_ctx=$(printf '%s' "$group_models" | jq -r ".[$selected_idx].context")
+  selected_output=$(printf '%s' "$group_models" | jq -r ".[$selected_idx].max_output")
+
+  # Set env vars
+  export COPILOT_PROVIDER_BASE_URL="$_CPM_OR_BASE_URL"
+  export COPILOT_PROVIDER_TYPE="$_CPM_OR_PROVIDER_TYPE"
+  export COPILOT_MODEL="$selected_id"
+
+  # Resolve API key
+  local or_key
+  or_key="${OPENROUTER_API_KEY:-}"
+  if [ -n "$or_key" ]; then
+    export COPILOT_PROVIDER_API_KEY="$or_key"
+  fi
+
+  # Token limits
+  if [ "$selected_ctx" -gt 0 ] 2>/dev/null; then
+    export COPILOT_PROVIDER_MAX_PROMPT_TOKENS="$selected_ctx"
+  else
+    unset COPILOT_PROVIDER_MAX_PROMPT_TOKENS
+  fi
+  if [ "$selected_output" -gt 0 ] 2>/dev/null; then
+    export COPILOT_PROVIDER_MAX_OUTPUT_TOKENS="$selected_output"
+  else
+    unset COPILOT_PROVIDER_MAX_OUTPUT_TOKENS
+  fi
+
+  echo ""
+  echo "  ✓ Switched to OpenRouter > $selected_id"
+  echo ""
+
+  # Step 3: offer to save to config
+  local save_choice
+  printf "  Save to cpm config for quick access? [y/N]: "
+  read -r save_choice
+  if [ "$save_choice" = "y" ] || [ "$save_choice" = "Y" ]; then
+    # Check if OpenRouter provider exists in config
+    local or_exists
+    or_exists=$(jq '[.providers[] | select(.name == "OpenRouter")] | length' "$CPM_CONFIG_FILE")
+
+    if [ "$or_exists" -gt 0 ]; then
+      # Check if model already exists
+      local model_exists
+      model_exists=$(jq --arg id "$selected_id" '[.providers[] | select(.name == "OpenRouter").models[] | select(.id == $id)] | length' "$CPM_CONFIG_FILE")
+      if [ "$model_exists" -eq 0 ]; then
+        jq --arg id "$selected_id" --argjson ctx "$selected_ctx" --argjson out "$selected_output" \
+          '(.providers[] | select(.name == "OpenRouter")).models += [{id: $id, max_prompt_tokens: $ctx, max_output_tokens: $out}]' \
+          "$CPM_CONFIG_FILE" > "$CPM_CONFIG_FILE.tmp" && mv "$CPM_CONFIG_FILE.tmp" "$CPM_CONFIG_FILE"
+        echo "  ✓ Saved '$selected_id' to OpenRouter in config."
+      else
+        echo "  Model already exists in config."
+      fi
+    else
+      # Create OpenRouter provider
+      jq --arg id "$selected_id" --argjson ctx "$selected_ctx" --argjson out "$selected_output" \
+        '.providers += [{
+          name: "OpenRouter",
+          base_url: "https://openrouter.ai/api/v1",
+          provider_type: "openai",
+          api_key_env: "OPENROUTER_API_KEY",
+          models: [{id: $id, max_prompt_tokens: $ctx, max_output_tokens: $out}]
+        }]' \
+        "$CPM_CONFIG_FILE" > "$CPM_CONFIG_FILE.tmp" && mv "$CPM_CONFIG_FILE.tmp" "$CPM_CONFIG_FILE"
+      echo "  ✓ Created OpenRouter provider and saved '$selected_id'."
+    fi
+  fi
+
+  echo ""
+  _cpm_launch
+}
+
 _cpm_help() {
   cat <<'EOF'
 Usage: cpm [command]
@@ -609,6 +815,7 @@ Commands:
   config    Get/set config values (e.g. cpm config launch yolo)
   edit      Open models.json in $EDITOR
   import    Import models from VS Code chatLanguageModels.json
+  discover  Discover & select models from OpenRouter API
   clear     Unset all Copilot provider env vars
   uninstall Remove cpm config, script, and profile entries
   help      Show this help

--- a/cpm.sh
+++ b/cpm.sh
@@ -647,6 +647,8 @@ _cpm_discover() {
   local group_count
   group_count=$(printf '%s' "$groups" | jq 'length')
 
+  local total_options=$((group_count + 1))
+
   echo "  Found $total_count models with tool-calling support"
   echo "  across $group_count provider groups."
   echo ""
@@ -664,6 +666,9 @@ _cpm_discover() {
     gi=$((gi + 1))
   done
 
+  # Special option: OpenRouter Free Router
+  printf "  %3d) %-20s\n" "$total_options" "openrouter/free (auto)"
+
   if [ "$group_count" -eq 0 ]; then
     echo "  No provider groups found." >&2
     return 1
@@ -672,16 +677,25 @@ _cpm_discover() {
   echo ""
   local gchoice
   while true; do
-    printf "  Pick a group (1-%d): " "$group_count"
+    printf "  Pick a group (1-%d): " "$total_options"
     read -r gchoice
     case "$gchoice" in
       ''|*[!0-9]*) echo "  Invalid choice." >&2; continue ;;
     esac
-    if [ "$gchoice" -ge 1 ] && [ "$gchoice" -le "$group_count" ]; then
+    if [ "$gchoice" -ge 1 ] && [ "$gchoice" -le "$total_options" ]; then
       break
     fi
     echo "  Invalid choice." >&2
   done
+
+  # Handle OpenRouter Free Router
+  if [ "$gchoice" -eq "$total_options" ]; then
+    echo ""
+    echo "  Using OpenRouter Free Router — auto-selects best free model."
+    echo ""
+    _cpm_discover_activate "openrouter/free" 0 0
+    return $?
+  fi
 
   local selected_group
   selected_group=$(printf '%s' "$groups" | jq -r ".[$((gchoice - 1))].group")
@@ -746,6 +760,14 @@ _cpm_discover() {
   selected_id=$(printf '%s' "$group_models" | jq -r ".[$selected_idx].id")
   selected_ctx=$(printf '%s' "$group_models" | jq -r ".[$selected_idx].context")
   selected_output=$(printf '%s' "$group_models" | jq -r ".[$selected_idx].max_output")
+
+  _cpm_discover_activate "$selected_id" "$selected_ctx" "$selected_output"
+}
+
+# ── activate selected model ────────────────────────────────────────────
+
+_cpm_discover_activate() {
+  local selected_id="$1" selected_ctx="$2" selected_output="$3"
 
   # Set env vars
   export COPILOT_PROVIDER_BASE_URL="$_CPM_OR_BASE_URL"

--- a/cpm.sh
+++ b/cpm.sh
@@ -737,9 +737,24 @@ _cpm_discover() {
   export COPILOT_PROVIDER_TYPE="$_CPM_OR_PROVIDER_TYPE"
   export COPILOT_MODEL="$selected_id"
 
-  # Resolve API key
+  # Resolve API key — warn / prompt if missing
   local or_key
   or_key="${OPENROUTER_API_KEY:-}"
+  if [ -z "$or_key" ]; then
+    echo "  OpenRouter API key (\$OPENROUTER_API_KEY) is not set."
+    echo "  It must be set before using OpenRouter models."
+    echo ""
+    printf "  Paste your OpenRouter API key (sk-or-...): "
+    read -r or_key
+    if [ -n "$or_key" ]; then
+      export OPENROUTER_API_KEY="$or_key"
+      echo "  ✓ \$OPENROUTER_API_KEY set for this session."
+      echo "  Tip: add 'export OPENROUTER_API_KEY=...' to ~/.bashrc for persistence."
+    else
+      echo "  No key provided. Authentication will likely fail." >&2
+    fi
+    echo ""
+  fi
   if [ -n "$or_key" ]; then
     export COPILOT_PROVIDER_API_KEY="$or_key"
   fi

--- a/cpm.sh
+++ b/cpm.sh
@@ -628,14 +628,17 @@ _cpm_discover() {
     return 1
   fi
 
-  # Build a flat list of { provider_group, model_id, name, context }
+  # Build a flat list of { group, id, name, context, max_output, pricing }
   local models_json
   models_json=$(printf '%s' "$raw_json" | jq '[.data[] | {
     group: (.id | split("/")[0]),
     id: .id,
     name: (.id | split("/")[1:] | join("/")),
     context: (.top_provider.context_length // .context_length // 0),
-    max_output: (.top_provider.max_completion_tokens // 0)
+    max_output: (.top_provider.max_completion_tokens // 0),
+    is_free: (.id | test(":free$")),
+    prompt_cost: (.pricing.prompt // "") ,
+    completion_cost: (.pricing.completion // "")
   }]')
 
   local groups
@@ -696,10 +699,13 @@ _cpm_discover() {
 
   local mi=0
   while [ "$mi" -lt "$group_model_count" ]; do
-    local mid mname mctx
+    local mid mname mctx mfree mprompt mcompletion
     mid=$(printf '%s' "$group_models" | jq -r ".[$mi].id")
     mname=$(printf '%s' "$group_models" | jq -r ".[$mi].name")
     mctx=$(printf '%s' "$group_models" | jq -r ".[$mi].context")
+    mfree=$(printf '%s' "$group_models" | jq -r ".[$mi].is_free")
+    mprompt=$(printf '%s' "$group_models" | jq -r ".[$mi].prompt_cost")
+    mcompletion=$(printf '%s' "$group_models" | jq -r ".[$mi].completion_cost")
     local ctx_fmt=""
     if [ "$mctx" -gt 0 ] 2>/dev/null; then
       if [ "$mctx" -ge 1000000 ]; then
@@ -708,7 +714,16 @@ _cpm_discover() {
         ctx_fmt="$((mctx / 1000))k ctx"
       fi
     fi
-    printf "  %3d) %-45s %s\n" "$((mi + 1))" "$mid" "$ctx_fmt"
+    local price_tag=""
+    if [ "$mfree" = "true" ]; then
+      price_tag=" FREE"
+    elif [ -n "$mprompt" ] && [ "$mprompt" != "null" ] && [ -n "$mcompletion" ] && [ "$mcompletion" != "null" ]; then
+      local p_prompt p_completion
+      p_prompt=$(printf '%s' "$mprompt" | awk '{printf "%.1f", $1 * 1000000}')
+      p_completion=$(printf '%s' "$mcompletion" | awk '{printf "%.1f", $1 * 1000000}')
+      price_tag=" \$${p_prompt}/\$${p_completion}/M"
+    fi
+    printf "  %3d) %-42s %s%s\n" "$((mi + 1))" "$mid" "$ctx_fmt" "$price_tag"
     mi=$((mi + 1))
   done
 

--- a/cpm.sh
+++ b/cpm.sh
@@ -757,6 +757,10 @@ _cpm_discover() {
   fi
   if [ -n "$or_key" ]; then
     export COPILOT_PROVIDER_API_KEY="$or_key"
+    export COPILOT_PROVIDER_BEARER_TOKEN="$or_key"
+    echo "  ✓ API key resolved (${or_key:0:11}...)"
+  else
+    echo "  ⚠ No API key set — copilot will fail with 403." >&2
   fi
 
   # Token limits


### PR DESCRIPTION
## Summary

Adds `cpm discover` — a command that fetches available models directly from OpenRouter's public API and lets you pick one interactively.

## Motivation

OpenRouter hosts 450+ models across 30+ providers. Maintaining a static `models.json` for all of them is impractical — models are added and deprecated daily. `cpm discover` solves this by querying the live API.

## How it works

1. **Fetch**: Calls `GET /api/v1/models?supported_parameters=tools` (public, no auth needed)
2. **Group**: Models are grouped by provider family (e.g. `anthropic`, `openai`, `google`, `deepseek`, `qwen`)
3. **Pick**: Two-level interactive picker — choose a group, then a specific model
4. **Activate**: Sets all `COPILOT_PROVIDER_*` env vars (base URL, model, type, API key, token limits)
5. **Save (optional)**: Offers to persist the selected model to `models.json` for future `cpm` quick access

## Context windows

Automatically reads `top_provider.context_length` and `top_provider.max_completion_tokens` from the API response and sets `COPILOT_PROVIDER_MAX_PROMPT_TOKENS` / `COPILOT_PROVIDER_MAX_OUTPUT_TOKENS` accordingly.

## UX preview

```
$ cpm discover

  Fetching models from OpenRouter...

  Found 247 models with tool-calling support across 32 provider groups.

  Provider groups:
    1) ai21                 (1 models)
    2) anthropic            (15 models)
    3) deepseek             (10 models)
    ...

  Pick a group (1-32): 2

  Models in 'anthropic':
    1) anthropic/claude-sonnet-5                200k ctx
    2) anthropic/claude-opus-4                  200k ctx
    ...

  Pick a model (1-15): 1

  Switched to OpenRouter > anthropic/claude-sonnet-5

  Save to cpm config for quick access? [y/N]: y
  Saved 'anthropic/claude-sonnet-5' to OpenRouter in config.
```

## Testing

- Verified with 247 real models from OpenRouter's live API
- jq injection: group name passed via `--arg` (not string interpolation)
- Bash arithmetic used instead of `bc` for portability
- Syntax validated with `bash -n`
